### PR TITLE
Fix bugs #104, #101, #29 and migrate to ep_plugin_helpers

### DIFF
--- a/fonts.js
+++ b/fonts.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// Shared font list — single source of truth for client, server, and shared code.
+module.exports = [
+  'fontarial',
+  'fontavant-garde',
+  'fontbookman',
+  'fontcalibri',
+  'fontcourier',
+  'fontgaramond',
+  'fonthelvetica',
+  'fontmonospace',
+  'fontpalatino',
+  'fonttimes-new-roman',
+];

--- a/index.js
+++ b/index.js
@@ -1,64 +1,29 @@
 'use strict';
 
-const fonts = [
-  'fontarial',
-  'fontavant-garde',
-  'fontbookman',
-  'fontcalibri',
-  'fontcourier',
-  'fontgaramond',
-  'fonthelvetica',
-  'fontmonospace',
-  'fontpalatino',
-  'fonttimes-new-roman',
-];
+const fonts = require('./fonts');
+const {template} = require('ep_plugin_helpers');
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+exports.eejsBlock_editbarMenuLeft = template('ep_font_family/templates/editbarButtons.ejs');
+exports.eejsBlock_dd_format = template('ep_font_family/templates/fileMenu.ejs');
 
-/** ******************
-* UI
-*/
-exports.eejsBlock_editbarMenuLeft = (hookName, args, cb) => {
-  args.content += eejs.require('ep_font_family/templates/editbarButtons.ejs');
-  return cb();
-};
-
-exports.eejsBlock_dd_format = (hookName, args, cb) => {
-  args.content += eejs.require('ep_font_family/templates/fileMenu.ejs');
-  return cb();
-};
-
-
-/** ******************
-* Editor
-*/
-
-// Allow <whatever> to be an attribute
+// Server-side aceAttribClasses — maps font names to tag: prefix.
+// This must match the client-side mapping exactly.
 exports.aceAttribClasses = (hookName, attr, cb) => {
   for (const font of fonts) {
-    attr[font] = `tag:font${font}`;
+    attr[font] = `tag:${font}`;
   }
   return cb(attr);
 };
 
-/** ******************
-* Export
-*/
-
-// Add the props to be supported in export
-exports.exportHtmlAdditionalTags = (hook, pad, cb) => {
-  return cb(fonts);
-};
+exports.exportHtmlAdditionalTags = (hook, pad, cb) => cb(fonts);
 
 exports.getLineHTMLForExport = async (hook, context) => {
   let lineContent = context.lineContent;
-  fonts.forEach((font) => {
-    if (lineContent) {
-      const fontName = font.substring(4);
-      lineContent = lineContent.replaceAll(`<${font}`, `<span style='font-family:${fontName}'`);
-      lineContent = lineContent.replaceAll(`</${font}`, '</span');
-    }
-  });
+  for (const font of fonts) {
+    if (!lineContent) break;
+    const fontName = font.substring(4);
+    lineContent = lineContent.replaceAll(`<${font}`, `<span style='font-family:${fontName}'`);
+    lineContent = lineContent.replaceAll(`</${font}`, '</span');
+  }
   context.lineContent = lineContent;
 };
-

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "individual",
     "url": "https://etherpad.org/"
   },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.2.0"
+  },
   "devDependencies": {
     "eslint": "^8.57.1",
     "eslint-config-etherpad": "^4.0.4",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,108 +1,57 @@
 'use strict';
 
-const fonts = [
-  'fontarial',
-  'fontavant-garde',
-  'fontbookman',
-  'fontcalibri',
-  'fontcourier',
-  'fontgaramond',
-  'fonthelvetica',
-  'fontmonospace',
-  'fontpalatino',
-  'fonttimes-new-roman',
-];
+const {tagAttribute} = require('ep_plugin_helpers/attributes');
+const fonts = require('../../fonts');
 
-/** ***
-* Basic setup
-******/
+const fontFamily = tagAttribute({tags: fonts});
 
-// Bind the event handler to the toolbar buttons
+exports.aceAttribsToClasses = fontFamily.aceAttribsToClasses;
+exports.aceRegisterBlockElements = fontFamily.aceRegisterBlockElements;
+exports.aceAttribClasses = fontFamily.aceAttribClasses;
+
 exports.postAceInit = (hook, context) => {
-  const fontFamily = $('select.family-selection');
-  $.each(fonts, (k, font) => {
-    font = font.substring(4);
-    let fontString = capitaliseFirstLetter(font);
-    fontString = fontString.split('-').join(' ');
-    fontFamily.append($('<option>').attr('value', `font${font}`).text(fontString));
-  });
-  fontFamily.niceSelect('update');
-  fontFamily.on('change', function () {
+  const select = $('select.family-selection');
+  for (const font of fonts) {
+    const name = font.substring(4);
+    let label = name.charAt(0).toUpperCase() + name.slice(1);
+    label = label.split('-').join(' ');
+    select.append($('<option>').attr('value', font).text(label));
+  }
+  select.niceSelect('update');
+  select.on('change', function () {
     const value = $(this).val();
     context.ace.callWithAce((ace) => {
-      // remove all other attrs
-      $.each(fonts, (k, v) => {
-        ace.ace_setAttributeOnSelection(v, false);
-      });
+      for (const f of fonts) {
+        ace.ace_setAttributeOnSelection(f, false);
+      }
       ace.ace_setAttributeOnSelection(value, true);
     }, 'insertfontFamily', true);
     context.ace.focus();
   });
 };
 
-// To do show what font family is active on current selection
 exports.aceEditEvent = (hook, call) => {
   const cs = call.callstack;
-
   if (!(cs.type === 'handleClick') && !(cs.type === 'handleKeyEvent') && !(cs.docTextChanged)) {
     return false;
   }
-
-  // If it's an initial setup event then do nothing..
   if (cs.type === 'setBaseText' || cs.type === 'setup') return false;
-  // It looks like we should check to see if this section has this attribute
-  setTimeout(() => { // avoid race condition..
-    $('.family-selection').val('dummy'); // reset value to the dummy value
 
-    // Attribtes are never available on the first X caret position so we need to ignore that
-    if (call.rep.selStart[1] === 0) {
-      // Attributes are never on the first line
-      return;
-    }
-    // The line has an attribute set, this means it wont get hte correct X caret position
-    if (call.rep.selStart[1] === 1) {
-      if (call.rep.alltext[0] === '*') {
-        // Attributes are never on the "first" character of lines with attributes
-        return;
+  setTimeout(() => {
+    const select = $('.family-selection');
+    select.val('dummy');
+
+    if (call.rep.selStart[1] === 0) return;
+    if (call.rep.selStart[1] === 1 && call.rep.alltext[0] === '*') return;
+
+    for (const font of fonts) {
+      if (call.editorInfo.ace_getAttributeOnSelection(font)) {
+        select.val(font);
+        break;
       }
     }
-    // the caret is in a new position.. Let's do some funky shit
-    $('.subscript > a').removeClass('activeButton');
-    $.each(fonts, (k, v) => {
-      if (call.editorInfo.ace_getAttributeOnSelection(v)) {
-        // show the button as being depressed.. Not sad, but active..
-        $('.family-selection').val(v);
-      }
-    });
+    select.niceSelect('update');
   }, 250);
 };
 
-/** ***
-* Editor setup
-******/
-
-// Our fontFamily attribute will result in a class
-// I'm not sure if this is actually required..
-exports.aceAttribsToClasses = (hook, context) => {
-  if (fonts.indexOf(context.key) !== -1) {
-    return [context.key];
-  }
-};
-
-// Block elements
-// I'm not sure if this is actually required..
-exports.aceRegisterBlockElements = () => fonts;
-
-// Register attributes that are html markup / blocks not just classes
-// This should make export export properly IE <sub>helllo</sub>world
-// will be the output and not <span class=sub>helllo</span>
-exports.aceAttribClasses = (hookName, attr) => {
-  $.each(fonts, (k, v) => {
-    attr[v] = `tag:${v}`;
-  });
-  return attr;
-};
-
-exports.aceEditorCSS = (hookName, cb) => ['/ep_font_family/static/css/fonts.css'];
-
-const capitaliseFirstLetter = (string) => string.charAt(0).toUpperCase() + string.slice(1);
+exports.aceEditorCSS = () => ['/ep_font_family/static/css/fonts.css'];

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -1,34 +1,9 @@
 'use strict';
 
-const fonts = [
-  'fontarial',
-  'fontavant-garde',
-  'fontbookman',
-  'fontcalibri',
-  'fontcourier',
-  'fontgaramond',
-  'fonthelvetica',
-  'fontmonospace',
-  'fontpalatino',
-  'fonttimes-new-roman',
-];
+const {tagAttribute} = require('ep_plugin_helpers/attributes');
+const fonts = require('../../fonts');
 
-exports.collectContentPre = (hook, context) => {
-  const tname = context.tname;
-  const state = context.state;
-  if (fonts.indexOf(tname) !== -1) {
-    context.cc.doAttrib(state, tname);
-  }
-};
+const fontFamily = tagAttribute({tags: fonts});
 
-// never seems to be run
-exports.collectContentPost = (hook, context) => {
-  const tname = context.tname;
-  const state = context.state;
-  const lineAttributes = state.lineAttributes;
-  const tagIndex = tname;
-
-  if (tagIndex >= 0) {
-    delete lineAttributes.sub;
-  }
-};
+exports.collectContentPre = fontFamily.collectContentPre;
+exports.collectContentPost = fontFamily.collectContentPost;


### PR DESCRIPTION
## Summary

Fixes three reported bugs and migrates to ep_plugin_helpers. Net -93 lines.

### Bugs fixed

- **#104 Font not changing** — server-side `aceAttribClasses` mapped `fontarial` to `tag:fontfontarial` (double "font" prefix). Fixed to `tag:fontarial`.
- **#101 Init error** — template resolution issue. Simplified with `template()` helper.
- **#29 Dropdown not updating** — `aceEditEvent` didn't call `niceSelect('update')` after changing the select value.

### Also fixed

- `collectContentPost` had copy-paste bug from subscript plugin — deleted `lineAttributes.sub` instead of the font attribute
- Fonts array duplicated in 3 files — extracted to shared `fonts.js`

## Test plan

- [ ] Select text, change font — font renders correctly
- [ ] Move cursor out of styled text — dropdown resets to default
- [ ] Move cursor into styled text — dropdown shows correct font
- [ ] Export pad as HTML — fonts preserved as inline styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)