### PR TITLE
fix: render font options server-side so File menu picks them up (#28)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@
 const fonts = require('./fonts');
 const {template} = require('ep_plugin_helpers');
 
-exports.eejsBlock_editbarMenuLeft = template('ep_font_family/templates/editbarButtons.ejs');
-exports.eejsBlock_dd_format = template('ep_font_family/templates/fileMenu.ejs');
+exports.eejsBlock_editbarMenuLeft = template(
+    'ep_font_family/templates/editbarButtons.ejs', {vars: () => ({fonts})});
+exports.eejsBlock_dd_format = template(
+    'ep_font_family/templates/fileMenu.ejs', {vars: () => ({fonts})});
 
 // Server-side aceAttribClasses — maps font names to tag: prefix.
 // This must match the client-side mapping exactly.

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -10,14 +10,12 @@ exports.aceRegisterBlockElements = fontFamily.aceRegisterBlockElements;
 exports.aceAttribClasses = fontFamily.aceAttribClasses;
 
 exports.postAceInit = (hook, context) => {
+  // Font options are rendered server-side by the editbarButtons.ejs and
+  // fileMenu.ejs templates (from ./fonts.js). Previously this hook
+  // appended them after Etherpad had already wrapped the <select> in
+  // niceSelect, so the File menu dropdown showed only the placeholder
+  // (#28). We just bind the change handler here.
   const select = $('select.family-selection');
-  for (const font of fonts) {
-    const name = font.substring(4);
-    let label = name.charAt(0).toUpperCase() + name.slice(1);
-    label = label.split('-').join(' ');
-    select.append($('<option>').attr('value', font).text(label));
-  }
-  select.niceSelect('update');
   select.on('change', function () {
     const value = $(this).val();
     context.ace.callWithAce((ace) => {

--- a/static/tests/backend/specs/filemenu_options.js
+++ b/static/tests/backend/specs/filemenu_options.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ep_etherpad-lite/node_modules/ejs');
+const fonts = require('../../../..' + '/fonts');
+
+const fileMenuTmpl = path.resolve(
+    __dirname, '..', '..', '..', '..', 'templates', 'fileMenu.ejs');
+const editbarTmpl = path.resolve(
+    __dirname, '..', '..', '..', '..', 'templates', 'editbarButtons.ejs');
+
+const render = (p) => ejs.render(fs.readFileSync(p, 'utf8'), {fonts});
+
+describe(__filename, function () {
+  it('fileMenu.ejs renders an <option> per font (#28)', function () {
+    const html = render(fileMenuTmpl);
+    for (const font of fonts) {
+      assert(html.includes(`value="${font}"`),
+          `file menu template should render an option for font ${font}; got:\n${html}`);
+    }
+  });
+
+  it('editbarButtons.ejs renders an <option> per font (#28)', function () {
+    const html = render(editbarTmpl);
+    for (const font of fonts) {
+      assert(html.includes(`value="${font}"`),
+          `editbar template should render an option for font ${font}; got:\n${html}`);
+    }
+  });
+});

--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -6,5 +6,10 @@
             data-l10n-id="ep_font_family.font"
             data-l10n-attr="aria-label">
         <option value="dummy" selected data-l10n-id="ep_font_family.family">Font</option>
+<% fonts.forEach((font) => {
+     const name = font.substring(4);
+     const label = (name.charAt(0).toUpperCase() + name.slice(1)).split('-').join(' '); %>
+        <option value="<%= font %>"><%= label %></option>
+<% }); %>
     </select>
 </li>

--- a/templates/fileMenu.ejs
+++ b/templates/fileMenu.ejs
@@ -2,6 +2,11 @@
   <ul class="submenu">
     <select class="family-selection">
       <option value="dummy" selected data-l10n-id="ep_font_family.family">family</option>
+<% fonts.forEach((font) => {
+     const name = font.substring(4);
+     const label = (name.charAt(0).toUpperCase() + name.slice(1)).split('-').join(' '); %>
+      <option value="<%= font %>"><%= label %></option>
+<% }); %>
     </select>
   </ul>
 </li>


### PR DESCRIPTION
Fixes #28. `postAceInit` was appending font options to every `.family-selection` at runtime, but Etherpad had already wrapped the File-menu select with niceSelect by that time — niceSelect renders its own DOM at init time and ignores later option inserts. The editbar dropdown worked (because it was re-read) but the File menu dropdown was stuck on the "family" placeholder. Render the options from `fonts.js` inside the EJS templates so niceSelect sees them on first init, and drop the now-redundant client-side loop. Backend spec asserts every font in `fonts.js` is rendered as an `<option>` by both templates.